### PR TITLE
Enable GitHub secret for API key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Inject API key
+        env:
+          UNSPLASH_API_KEY: ${{ secrets.UNSPLASH_API_KEY }}
+        run: |
+          sed -i 's/__UNSPLASH_API_KEY__/'"$UNSPLASH_API_KEY"'/g' script.js
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 This application is a web-based Pictionary suggestion tool, designed to randomly suggest objects to draw from a predefined list. It features a minimalist design with a large, central display for the suggestion text, ensuring high visibility. Upon clicking a button, users receive a random suggestion accompanied by a dynamically fetched image from the Unsplash API, providing a visual reference. The interface uses HTML for structure, CSS for styling with an elegant, modern look, and JavaScript for functionality, including API integration for real-time image retrieval. It's ideal for enhancing Pictionary games, offering both textual and visual prompts in a user-friendly format.
 
 DEMO: https://sauravabc16.github.io/pictionary/
+
+## Deployment with GitHub Pages
+
+The application expects an Unsplash API key, which is injected at deployment
+time. Store your key in the repository secrets as `UNSPLASH_API_KEY`. A GitHub
+Actions workflow will replace the placeholder in `script.js` and deploy the site
+to GitHub Pages automatically when changes are pushed to the `main` branch.

--- a/script.js
+++ b/script.js
@@ -558,7 +558,7 @@ function shuffleArray(array) {
 }
 
 async function fetchImage(query) {
-    const apiKey = '8WBSyxeJJIkprZJ_8027n3G3r3PKQniC6x5fCcg_qUs';
+    const apiKey = '__UNSPLASH_API_KEY__';
     const url = `https://api.unsplash.com/search/photos?page=1&query=${encodeURIComponent(query)}&client_id=${apiKey}`;
 
     try {


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy to Pages
- fetch Unsplash API key from GitHub secret during deployment
- document the secret workflow
- replace the hard-coded API key with a placeholder

## Testing
- `git status --short`

